### PR TITLE
Make dotnet check cross-platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function run() {
     if (!nugetKey)
         return
 
-    if (!runCap("command -v dotnet")) {
+    if (!runCap("dotnet --version")) {
         failure("😭 dotnet not found")
         return
     }

--- a/index.js
+++ b/index.js
@@ -52,8 +52,10 @@ function run() {
     // pack & push
     const nugetKey = process.env.INPUT_NUGET_KEY
 
-    if (!nugetKey)
+    if (!nugetKey) {
+        console.log(`😢 no nuget_key input supplied`)
         return
+    }
 
     if (!runCap("dotnet --version")) {
         failure("😭 dotnet not found")
@@ -61,9 +63,7 @@ function run() {
     }
 
     runProc(`dotnet pack -c Release ${projPath} -o .`)
-
-    if (nugetKey)
-        runProc(`dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${nugetKey}`)
+    runProc(`dotnet nuget push *.nupkg -s https://api.nuget.org/v3/index.json -k ${nugetKey}`)
 }
 
 function runCap(cmd) { return runCmd(cmd, { encoding: "utf-8" }).stdout }


### PR DESCRIPTION
The `command` command is not available outside powershell on windows, so the dotnet check fails:
https://github.com/cuzzlor/password-check/commit/c72e77d93f3d52b8e924547ba9937aee01b4b2ee/checks?check_suite_id=365776138