### PR TITLE
Add ability to specify PACKAGE_NAME

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
     NUGET_KEY:
         description: API key for the NuGet feed
         required: false
+    PACKAGE_NAME:
+        description: NuGet package name to check when looking for already-published versions
+        required: false
 
 runs:
     using: node12

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ class Action {
         this.TAG_COMMIT = JSON.parse(process.env.INPUT_TAG_COMMIT || process.env.TAG_COMMIT)
         this.TAG_FORMAT = process.env.INPUT_TAG_FORMAT || process.env.TAG_FORMAT
         this.NUGET_KEY = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
+        this.PACKAGE_NAME = process.env.INPUT_PACKAGE_NAME || process.env.PACKAGE_NAME
     }
 
     _warn(msg) {
@@ -93,10 +94,11 @@ class Action {
         if (!VERSION_INFO)
             this._fail("😢 unable to extract version info")
 
-        const CURRENT_VERSION = VERSION_INFO[1],
-            PACKAGE_NAME = path.basename(this.PROJECT_FILE_PATH).split(".").slice(0, -1).join(".")
+        const CURRENT_VERSION = VERSION_INFO[1]
+        if (!this.PACKAGE_NAME)
+            this.PACKAGE_NAME = path.basename(this.PROJECT_FILE_PATH).split(".").slice(0, -1).join(".")
 
-        https.get(`https://api.nuget.org/v3-flatcontainer/${PACKAGE_NAME}/index.json`, res => {
+        https.get(`https://api.nuget.org/v3-flatcontainer/${this.PACKAGE_NAME}/index.json`, res => {
             let body = ""
 
             if (res.statusCode == 404)

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ class Action {
     }
 
     _execCmd(cmd, options) {
-        const INPUT = cmd.split(" "), TOOL = INPUT[0], ARGS = INPUT.slice(1)
+        const INPUT = cmd.split(" "),
+            TOOL = INPUT[0],
+            ARGS = INPUT.slice(1)
         return spawnSync(TOOL, ARGS, options)
     }
 
@@ -102,7 +104,7 @@ class Action {
             let body = ""
 
             if (res.statusCode == 404)
-                this._pushAndTag(CURRENT_VERSION, PACKAGE_NAME)
+                this._pushAndTag(CURRENT_VERSION, this.PACKAGE_NAME)
 
             if (res.statusCode == 200) {
                 res.setEncoding("utf8")
@@ -110,7 +112,7 @@ class Action {
                 res.on("end", () => {
                     const existingVersions = JSON.parse(body)
                     if (existingVersions.versions.indexOf(CURRENT_VERSION) < 0)
-                        this._pushAndTag(CURRENT_VERSION, PACKAGE_NAME)
+                        this._pushAndTag(CURRENT_VERSION, this.PACKAGE_NAME)
                 })
             }
         }).on("error", e => {


### PR DESCRIPTION
This PR adds the capability to specify a package name for checking versions on NuGet. It's not required, and if it's not set, the old behavior is used, so this shouldn't be a breaking change.

Thanks!

Closes #11 