### PR TITLE
External version resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Input | Default Value | Description
 PROJECT_FILE_PATH | | File path of the project to be packaged, relative to repository root
 VERSION_FILE_PATH | `[PROJECT_FILE_PATH]` | File path containing version info, relative to repository root
 VERSION_REGEX | `<Version>(.*)<\/Version>` | Regex pattern to extract version info in a capturing group
-VERSION_STATIC| |Bypasses version resolution; useful for external providers like Nerdbank.GitVersioning
+VERSION_STATIC| | Bypasses version resolution; useful for external providers like Nerdbank.GitVersioning
 TAG_COMMIT | `true` | Flag to enable / disable git tagging
 TAG_FORMAT | `v*` | `[*]` is a placeholder for the actual project version
 NUGET_KEY | | API key to authorize the package upload to nuget.org

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
           PROJECT_FILE_PATH: Core/Core.csproj # Relative to repository root
           # VERSION_FILE_PATH: Directory.Build.props # Filepath with version info, relative to repository root. Defaults to project file
           # VERSION_REGEX: <Version>(.*)<\/Version> # Regex pattern to extract version info in a capturing group
-          # VERSION_STATIC: Bypasses version resolution, useful for external providers like Nerdbank.GitVersioning
+          # VERSION_STATIC: Bypasses version resolution; useful for external providers like Nerdbank.GitVersioning
           # TAG_COMMIT: true # Flag to enable / disalge git tagging
           # TAG_FORMAT: v* # Format of the git tag, [*] gets replaced with version
           # NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key
@@ -49,6 +49,7 @@ Input | Default Value | Description
 PROJECT_FILE_PATH | | File path of the project to be packaged, relative to repository root
 VERSION_FILE_PATH | `[PROJECT_FILE_PATH]` | File path containing version info, relative to repository root
 VERSION_REGEX | `<Version>(.*)<\/Version>` | Regex pattern to extract version info in a capturing group
+VERSION_STATIC| |Bypasses version resolution; useful for external providers like Nerdbank.GitVersioning
 TAG_COMMIT | `true` | Flag to enable / disable git tagging
 TAG_FORMAT | `v*` | `[*]` is a placeholder for the actual project version
 NUGET_KEY | | API key to authorize the package upload to nuget.org

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ jobs:
           PROJECT_FILE_PATH: Core/Core.csproj # Relative to repository root
           # VERSION_FILE_PATH: Directory.Build.props # Filepath with version info, relative to repository root. Defaults to project file
           # VERSION_REGEX: <Version>(.*)<\/Version> # Regex pattern to extract version info in a capturing group
+          # VERSION_STATIC: Bypasses version resolution, useful for external providers like Nerdbank.GitVersioning
           # TAG_COMMIT: true # Flag to enable / disalge git tagging
           # TAG_FORMAT: v* # Format of the git tag, [*] gets replaced with version
           # NUGET_KEY: ${{secrets.NUGET_API_KEY}} # nuget.org API key

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
         description: Regex (with version in a capturing group) to extract the version from `VERSION_FILE_PATH`
         required: false
         default: <Version>(.*)<\/Version>
+    VERSION_STATIC:
+        description: Bypasses version resolution; useful for external providers like Nerdbank.GitVersioning
+        required: false
     TAG_COMMIT:
         description: Whether to create a tag when there's a version change
         required: false

--- a/action.yml
+++ b/action.yml
@@ -37,4 +37,3 @@ runs:
 
 branding:
     icon: package
-    color: blue

--- a/action.yml
+++ b/action.yml
@@ -37,3 +37,4 @@ runs:
 
 branding:
     icon: package
+    color: blue

--- a/index.js
+++ b/index.js
@@ -13,14 +13,6 @@ class Action {
         this.TAG_FORMAT = process.env.INPUT_TAG_FORMAT || process.env.TAG_FORMAT
         this.NUGET_KEY = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
         this.PACKAGE_NAME = process.env.INPUT_PACKAGE_NAME || process.env.PACKAGE_NAME
-        
-        console.log(`##[info] PROJECT_FILE_PATH ${this.PROJECT_FILE_PATH}`)
-        console.log(`##[info] VERSION_STATIC ${this.VERSION_STATIC}`)
-        console.log(`##[info] VERSION_FILE_PATH ${this.VERSION_FILE_PATH}`)
-        console.log(`##[info] VERSION_REGEX ${this.VERSION_REGEX}`)
-        console.log(`##[info] TAG_COMMIT ${this.TAG_COMMIT}`)
-        console.log(`##[info] TAG_FORMAT ${this.TAG_FORMAT}`)
-        console.log(`##[info] PACKAGE_NAME ${this.PACKAGE_NAME}`)
     }
 
     _warn(msg) {
@@ -92,6 +84,15 @@ class Action {
     }
 
     run() {
+        
+        console.log(`PROJECT_FILE_PATH ${this.PROJECT_FILE_PATH}`)
+        console.log(`VERSION_STATIC ${this.VERSION_STATIC}`)
+        console.log(`VERSION_FILE_PATH ${this.VERSION_FILE_PATH}`)
+        console.log(`VERSION_REGEX ${this.VERSION_REGEX}`)
+        console.log(`TAG_COMMIT ${this.TAG_COMMIT}`)
+        console.log(`TAG_FORMAT ${this.TAG_FORMAT}`)
+        console.log(`PACKAGE_NAME ${this.PACKAGE_NAME}`)
+        
         if (!this.PROJECT_FILE_PATH)
             this._fail("😭 project file not given")
         

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const path = require("path"),
 class Action {
     constructor() {
         this.PROJECT_FILE_PATH = process.env.INPUT_PROJECT_FILE_PATH
-        this.VERSION_STATIC = process.env.INPUT_VERSION_STATIC || process.env.VERSION_STATIC
         this.VERSION_FILE_PATH = process.env.INPUT_VERSION_FILE_PATH || process.env.VERSION_FILE_PATH
         this.VERSION_REGEX = new RegExp(process.env.INPUT_VERSION_REGEX || process.env.VERSION_REGEX)
+        this.VERSION_STATIC = process.env.INPUT_VERSION_STATIC || process.env.VERSION_STATIC
         this.TAG_COMMIT = JSON.parse(process.env.INPUT_TAG_COMMIT || process.env.TAG_COMMIT)
         this.TAG_FORMAT = process.env.INPUT_TAG_FORMAT || process.env.TAG_FORMAT
         this.NUGET_KEY = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
@@ -84,18 +84,8 @@ class Action {
     }
 
     run() {
-        
-        console.log(`PROJECT_FILE_PATH ${this.PROJECT_FILE_PATH}`)
-        console.log(`VERSION_STATIC ${this.VERSION_STATIC}`)
-        console.log(`VERSION_FILE_PATH ${this.VERSION_FILE_PATH}`)
-        console.log(`VERSION_REGEX ${this.VERSION_REGEX}`)
-        console.log(`TAG_COMMIT ${this.TAG_COMMIT}`)
-        console.log(`TAG_FORMAT ${this.TAG_FORMAT}`)
-        console.log(`PACKAGE_NAME ${this.PACKAGE_NAME}`)
-        
         if (!this.PROJECT_FILE_PATH)
             this._fail("😭 project file not given")
-        
         this.PROJECT_FILE_PATH = this._resolveIfExists(this.PROJECT_FILE_PATH, "😭 project file not found")
         
         let CURRENT_VERSION = ""

--- a/index.js
+++ b/index.js
@@ -13,6 +13,14 @@ class Action {
         this.TAG_FORMAT = process.env.INPUT_TAG_FORMAT || process.env.TAG_FORMAT
         this.NUGET_KEY = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
         this.PACKAGE_NAME = process.env.INPUT_PACKAGE_NAME || process.env.PACKAGE_NAME
+        
+        console.log(`##[info] PROJECT_FILE_PATH ${this.PROJECT_FILE_PATH}`)
+        console.log(`##[info] VERSION_STATIC ${this.VERSION_STATIC}`)
+        console.log(`##[info] VERSION_FILE_PATH ${this.VERSION_FILE_PATH}`)
+        console.log(`##[info] VERSION_REGEX ${this.VERSION_REGEX}`)
+        console.log(`##[info] TAG_COMMIT ${this.TAG_COMMIT}`)
+        console.log(`##[info] TAG_FORMAT ${this.TAG_FORMAT}`)
+        console.log(`##[info] PACKAGE_NAME ${this.PACKAGE_NAME}`)
     }
 
     _warn(msg) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const path = require("path"),
 class Action {
     constructor() {
         this.PROJECT_FILE_PATH = process.env.INPUT_PROJECT_FILE_PATH
+        this.VERSION_STATIC = process.env.INPUT_VERSION_STATIC || process.env.VERSION_STATIC
         this.VERSION_FILE_PATH = process.env.INPUT_VERSION_FILE_PATH || process.env.VERSION_FILE_PATH
         this.VERSION_REGEX = new RegExp(process.env.INPUT_VERSION_REGEX || process.env.VERSION_REGEX)
         this.TAG_COMMIT = JSON.parse(process.env.INPUT_TAG_COMMIT || process.env.TAG_COMMIT)
@@ -85,17 +86,24 @@ class Action {
     run() {
         if (!this.PROJECT_FILE_PATH)
             this._fail("😭 project file not given")
-
+        
         this.PROJECT_FILE_PATH = this._resolveIfExists(this.PROJECT_FILE_PATH, "😭 project file not found")
-        this.VERSION_FILE_PATH = !this.VERSION_FILE_PATH ? this.PROJECT_FILE_PATH : this._resolveIfExists(this.VERSION_FILE_PATH, "😭 version file not found")
+        
+        let CURRENT_VERSION = ""
+        
+        if (this.VERSION_STATIC)
+            CURRENT_VERSION = this.VERSION_STATIC
+        else {
+            this.VERSION_FILE_PATH = !this.VERSION_FILE_PATH ? this.PROJECT_FILE_PATH : this._resolveIfExists(this.VERSION_FILE_PATH, "😭 version file not found")
 
-        const FILE_CONTENT = fs.readFileSync(this.VERSION_FILE_PATH, { encoding: "utf-8" }),
-            VERSION_INFO = this.VERSION_REGEX.exec(FILE_CONTENT)
+            const FILE_CONTENT = fs.readFileSync(this.VERSION_FILE_PATH, { encoding: "utf-8" }),
+                VERSION_INFO = this.VERSION_REGEX.exec(FILE_CONTENT)
 
-        if (!VERSION_INFO)
-            this._fail("😢 unable to extract version info")
+            if (!VERSION_INFO)
+                this._fail("😢 unable to extract version info")
 
-        const CURRENT_VERSION = VERSION_INFO[1]
+            const CURRENT_VERSION = VERSION_INFO[1]
+        }
 
         if (!this.PACKAGE_NAME)
             this.PACKAGE_NAME = path.basename(this.PROJECT_FILE_PATH).split(".").slice(0, -1).join(".")

--- a/index.js
+++ b/index.js
@@ -91,9 +91,7 @@ class Action {
         
         let CURRENT_VERSION = ""
         
-        if (this.VERSION_STATIC)
-            CURRENT_VERSION = this.VERSION_STATIC
-        else {
+        if (!this.VERSION_STATIC) {
             this.VERSION_FILE_PATH = !this.VERSION_FILE_PATH ? this.PROJECT_FILE_PATH : this._resolveIfExists(this.VERSION_FILE_PATH, "😭 version file not found")
 
             const FILE_CONTENT = fs.readFileSync(this.VERSION_FILE_PATH, { encoding: "utf-8" }),
@@ -102,8 +100,9 @@ class Action {
             if (!VERSION_INFO)
                 this._fail("😢 unable to extract version info")
 
-            const CURRENT_VERSION = VERSION_INFO[1]
-        }
+            CURRENT_VERSION = VERSION_INFO[1]
+        } else
+            CURRENT_VERSION = this.VERSION_STATIC
 
         if (!this.PACKAGE_NAME)
             this.PACKAGE_NAME = path.basename(this.PROJECT_FILE_PATH).split(".").slice(0, -1).join(".")


### PR DESCRIPTION
This PR adds a new input, `VERSION_STATIC`.

In cases where project version is controlled by a 3rd-party like Nerdbank.GitVersioning there may be no `<Version>` entries in the project's *.csproj file, causing version resolution to fail.

This input allows the externally generated SEMVER value to be passed at job execution. Example:

```
      - name: Nerdbank.GitVersioning
        uses: AArnott/nbgv@v0.3
        with:
          setAllVars: true

      - uses: rohith/publish-nuget@v2
        with:
          PROJECT_FILE_PATH: nbgvProject/nbgvProject.csproj
          VERSION_STATIC: ${{env.NBGV_Version}}

```

